### PR TITLE
Pull html-formatted description from GraphQL

### DIFF
--- a/src/views/board.tsx
+++ b/src/views/board.tsx
@@ -199,9 +199,8 @@ const RecordDetails = ({ record, users, userVotes, forceUpdate }) => {
       <h1 className="RecordDetails__title">
         { record.referenceNum + ' ' + record.name }
       </h1>
-      <p>
-        { record.description }
-      </p>
+      <div dangerouslySetInnerHTML={record.description.htmlBody}>
+      </div>
       <UsersList record={record} users={users} userVotes={userVotes} forceUpdate={forceUpdate} />
     </div>
   )
@@ -322,7 +321,9 @@ const DiviItUpBoard = ({}) => {
                 id
                 name
                 path
-                description
+                description {
+                  htmlBody
+                }
                 assignedToUser {
                   id
                   avatarUrl
@@ -337,7 +338,9 @@ const DiviItUpBoard = ({}) => {
                 id
                 name
                 path
-                description
+                description {
+                  htmlBody
+                }
                 assignedToUser {
                   id
                   avatarUrl


### PR DESCRIPTION
The schema for `description` has changed. It's now an object instead of a field. This is using `dangerouslySetInnerHTML` to render that content. It's probably not the best way, but I'm a bit rusty on how to handle this!