### PR TITLE
Use correct API for dangerouslySetInnerHTML

### DIFF
--- a/src/views/board.tsx
+++ b/src/views/board.tsx
@@ -199,7 +199,7 @@ const RecordDetails = ({ record, users, userVotes, forceUpdate }) => {
       <h1 className="RecordDetails__title">
         { record.referenceNum + ' ' + record.name }
       </h1>
-      <div dangerouslySetInnerHTML={record.description.htmlBody}>
+      <div dangerouslySetInnerHTML={{__html: record.description.htmlBody}}>
       </div>
       <UsersList record={record} users={users} userVotes={userVotes} forceUpdate={forceUpdate} />
     </div>


### PR DESCRIPTION
See https://reactjs.org/docs/dom-elements.html#dangerouslysetinnerhtml for docs.

This was causing a crash on features with descriptions.